### PR TITLE
Split the Landing page into a tabbed interface

### DIFF
--- a/app/_attachments/css/tangerine.less
+++ b/app/_attachments/css/tangerine.less
@@ -847,6 +847,11 @@ button{
 #content{
   width: 80%;
   padding: 10px 5px 20px;
+
+  &.fullWidth {
+    width: 100%;
+    padding: 10px 15px 20px;
+  }
 }
 
 .clickable
@@ -1442,6 +1447,53 @@ table.basic_info
 {
   padding: 10px;
   box-shadow: 1px 2px 7px rgba(0,0,0,0.2);
+}
+
+/*
+ * TutorMenuView
+ */
+
+.TutorMenuView {
+  padding: 0 15px;
+
+  .tab {
+    padding: 10px 10px 4px 10px;
+    display: inline-block;
+    /*margin: 0 2px;*/
+    background: #fefefe;
+    color: #aaa;
+    top: 5px;
+    border: 1px solid #eee;
+    cursor: pointer;
+
+    &.first {
+      border-top-left-radius: 10px;
+      margin-left: 10px;
+    }
+
+    &.last {
+      border-top-right-radius: 10px;
+    }
+
+    &.selected {
+      padding-bottom: 5px;
+      border-bottom: none !important;
+      color: #f49b00;
+      background: #fff;
+    }
+  }
+
+  .tab_container {
+    vertical-align: middle;
+    margin-top: 15px;
+    margin-bottom: -1px;
+    z-index: 10;
+  }
+
+  section {
+    border: 1px solid #eee;
+    text-align:left !important;
+  }
 }
 
 /*

--- a/app/_attachments/css/tangerine.less.css
+++ b/app/_attachments/css/tangerine.less.css
@@ -792,6 +792,10 @@ button {
   width: 80%;
   padding: 10px 5px 20px;
 }
+#content.fullWidth {
+  width: 100%;
+  padding: 10px 15px 20px;
+}
 .clickable {
   cursor: pointer !important;
 }
@@ -1494,6 +1498,45 @@ table.basic_info td {
 .NotesView {
   padding: 10px;
   box-shadow: 1px 2px 7px rgba(0, 0, 0, 0.2);
+}
+/*
+ * TutorMenuView
+ */
+.TutorMenuView {
+  padding: 0 15px;
+}
+.TutorMenuView .tab {
+  padding: 10px 10px 4px 10px;
+  display: inline-block;
+  /*margin: 0 2px;*/
+  background: #fefefe;
+  color: #aaa;
+  top: 5px;
+  border: 1px solid #eee;
+  cursor: pointer;
+}
+.TutorMenuView .tab.first {
+  border-top-left-radius: 10px;
+  margin-left: 10px;
+}
+.TutorMenuView .tab.last {
+  border-top-right-radius: 10px;
+}
+.TutorMenuView .tab.selected {
+  padding-bottom: 5px;
+  border-bottom: none !important;
+  color: #f49b00;
+  background: #fff;
+}
+.TutorMenuView .tab_container {
+  vertical-align: middle;
+  margin-top: 15px;
+  margin-bottom: -1px;
+  z-index: 10;
+}
+.TutorMenuView section {
+  border: 1px solid #eee;
+  text-align: left !important;
 }
 /*
  * TutorAccountView

--- a/app/_attachments/index-dev.html
+++ b/app/_attachments/index-dev.html
@@ -168,6 +168,7 @@
 <script src='js/modules/user/UsersMenuView.js'></script>
 <script src='js/modules/user/UserEditView.js'></script>
 <script src='js/modules/user/TutorAccountView.js'></script>
+<script src='js/modules/user/TutorMenuView.js'></script>
 <script src='js/modules/workflow/WorkflowStep.js'></script>
 <script src='js/modules/workflow/WorkflowSteps.js'></script>
 <script src='js/modules/workflow/Workflow.js'></script>

--- a/app/_attachments/js/modules/syncManager/BandwidthCheckView.coffee
+++ b/app/_attachments/js/modules/syncManager/BandwidthCheckView.coffee
@@ -110,7 +110,7 @@ class BandwidthCheckView extends Backbone.View
 
   render: =>
     @$el.html "
-      <section class='BandwidthCheckView'>
+      <div class='BandwidthCheckView'>
         <h2>Network Connection Test</h2>
         <div class='grid grid-pad'>
           <div class='col-3-12'>
@@ -130,7 +130,7 @@ class BandwidthCheckView extends Backbone.View
       	<div class='results'>
       		<span class='results'></span>
       	</div>
-      </section>
+      </div>
     "
 
     @trigger "rendered"

--- a/app/_attachments/js/modules/syncManager/SyncManager.coffee
+++ b/app/_attachments/js/modules/syncManager/SyncManager.coffee
@@ -346,26 +346,23 @@ class SyncManagerView extends Backbone.View
 
   render: ( statusMessage = '' ) =>
 
-    @$el.html "<h1>Sync manager</h1>
-    <section>
-      <h2>Results</h2>
-      <table class='class_table'>
-        <tr>
-          <th>Synced results</th><td>#{@sunc.length}</td>
-        </tr>
-        <tr>
-          <th>Left to sync</th><td>#{@toSync}</td>
-        </tr>
-        <tr>
-          <td colspan='2'><button class='upload command'>Upload</button></td>
-        </tr>
-      </table>
-    </section>
-    <section>
-      <h2>Server results</h2>
-      <table id='sync-old-progress'></table>
-      <button class='sync-old command'>Sync</button>
-    </section>
+    @$el.html "
+    <h2>Sync Status</h2>
+    <table class='class_table'>
+      <tr>
+        <th>Synced results</th><td>#{@sunc.length}</td>
+      </tr>
+      <tr>
+        <th>Left to sync</th><td>#{@toSync}</td>
+      </tr>
+      <tr>
+        <th colspan='2'><button class='upload command'>Upload</button></th>
+      </tr>
+    </table>
+    <div style='margin-bottom:12px; padding-bottom: 12px; border-bottom: 1px solid #eee;'></div>
+    <h2>Server results</h2>
+    <table id='sync-old-progress'></table>
+    <button class='sync-old command'>Sync</button>
     "
 
 

--- a/app/_attachments/js/modules/user/TutorMenuView.coffee
+++ b/app/_attachments/js/modules/user/TutorMenuView.coffee
@@ -1,0 +1,102 @@
+class TutorMenuView extends Backbone.View
+
+  className : "TutorMenuView"
+
+  events:
+    "click .tab"	: 'handleTabClick'
+
+  i18n: ->
+    @text =
+      "title"      : t('TutorMenuView.title')
+      "workflows"   : t('TutorMenuView.tabs.workflows')
+      "sync"       : t('TutorMenuView.tabs.sync')
+      "schools"    : t('TutorMenuView.tabs.schools')
+
+  initialize: (options) =>
+    @[key] = value for key, value of options
+    @i18n()
+
+
+  handleTabClick: ( event ) =>
+    @$el.find('.tab').removeClass('selected')
+    @$el.find('.tab-panel').hide()
+    
+    #determine which tab was clicked and begin navigation
+    $target = $(event.target)
+    id = $target.attr('data-id')
+    Tangerine.router.navigate "tutor-menu/"+id , false
+    @displayTab(id)
+
+
+  displayTab: ( selectedTab = 'workflows') ->
+    @$el.find('#tab-'+selectedTab).addClass('selected')
+    @$el.find('#panel-'+selectedTab).show()
+
+
+  render: =>
+    @$el.html "
+      <h1>#{@text.title}</h1>
+      <div class='tab_container'>
+        <div id='tab-workflows' class='tab mode first' data-id='workflows'>#{@text.workflows}</div>
+        <div id='tab-sync' class='tab mode' data-id='sync'>#{@text.sync}</div>
+        <div id='tab-schools' class='tab mode last' data-id='schools'>#{@text.schools}</div>
+      </div>
+      <section id='panel-workflows' class='tab-panel' style='display:none;'>
+        <div id='workflows'></div>
+      </section>
+      <section id='panel-sync' class='tab-panel' style='display:none;'>
+        <div id='sync-manager'></div>
+        <div style='margin-bottom:12px; padding-bottom: 12px; border-bottom: 1px solid #eee;'></div>
+        <div id='bandwidth-test'></div>
+      </section>
+      <section id='panel-schools' class='tab-panel' style='display:none;'>
+        <div id='school-list'></div>
+        <div style='margin-bottom:12px; padding-bottom: 12px; border-bottom: 1px solid #eee;'></div>
+        <div id='valid-observations'></div>
+      </section>
+    "
+    unless @WorkflowMenuView?
+      instRef = @
+      (workflows = new Workflows).fetch
+        success: ->
+          if workflows.length > 0
+            feedbacks = new Feedbacks feedbacks
+            feedbacks.fetch
+              success: ->
+                instRef.WorkflowMenuView = new WorkflowMenuView
+                  workflows : workflows
+                  feedbacks : feedbacks
+                instRef.WorkflowMenuView.setElement(instRef.$el.find("#panel-workflows #workflows"))
+                instRef.WorkflowMenuView.render("loading")
+                return 
+            return
+
+    unless @syncManagerView?
+      @syncManagerView = new SyncManagerView
+      @syncManagerView.setElement(@$el.find("#panel-sync > #sync-manager"))
+      @listenTo @syncManagerView, "complete-sync", =>
+        @workflows.fetch
+          success: =>
+            console.log(@workflows)
+            @WorkflowMenuView.updateWorkflows()
+      @syncManagerView.render()
+
+    unless @bandwidthCheckView?
+      @bandwidthCheckView = new BandwidthCheckView
+      @bandwidthCheckView.setElement(@$el.find("#panel-sync > #bandwidth-test"))
+      @bandwidthCheckView.render()
+
+    unless @schoolListView?
+      @schoolListView = new SchoolListView
+      @schoolListView.setElement(@$el.find("#panel-schools > #school-list"))
+      @schoolListView.render("loading")
+
+    unless @validObservationView?
+      @validObservationView = new ValidObservationView
+      @validObservationView.setElement(@$el.find("#panel-schools > #valid-observations"))
+      @validObservationView.render("loading")
+    
+    #init the tabs by showing the selected tabs
+    @displayTab(@selectedTab)
+
+    @trigger "rendered"

--- a/app/_attachments/js/modules/viewManager/ViewManager.coffee
+++ b/app/_attachments/js/modules/viewManager/ViewManager.coffee
@@ -6,7 +6,7 @@
 # all the time in between a loading bar should appear. 
 class ViewManager extends Backbone.View
 
-  show: (view) =>
+  show: (view, setFullWidth = false) =>
 
     window.scrollTo 0, 0
 
@@ -18,6 +18,12 @@ class ViewManager extends Backbone.View
     Tangerine.log.app("show", @className)
 
     @currentView.on "rendered", =>
+
+      if setFullWidth
+        $('#content').addClass('fullWidth')
+      else
+        $('#content').removeClass('fullWidth')
+        
       $("#content").append @currentView.el
       @currentView.$el.find(".buttonset").buttonset()
       @currentView.afterRender?()

--- a/app/_attachments/js/modules/workflow/SchoolListView.coffee
+++ b/app/_attachments/js/modules/workflow/SchoolListView.coffee
@@ -171,23 +171,23 @@ class SchoolListView extends Backbone.View
         
     
     @$el.html "
-      <section>
-        <h2>School list</h2>
-        <table class='class_table'>
-          <tr><th>County</th><td>#{countySelect}</td></tr>
-          <tr><th>Zone</th><td>#{zoneSelect}</td></tr>
-          <tr><th>Schools remaining</th><td><button class='schools-left command'>#{@schools.left.length}</button></td></tr>
-        </table>
-        
-        <table class='class_table school-list start-hidden'>
-          <tr><td><b>Remaining</b></td></tr>
-          #{("<tr><td>#{school}</td></tr>" for school in @schools.left).join('')}
-        </table>
+      
+      <h2>School List</h2>
+      <table class='class_table'>
+        <tr><th>County</th><td>#{countySelect}</td></tr>
+        <tr><th>Zone</th><td>#{zoneSelect}</td></tr>
+        <tr><th>Schools remaining</th><td><button class='schools-left command'>#{@schools.left.length}</button></td></tr>
+      </table>
+      
+      <table class='class_table school-list start-hidden'>
+        <tr><td><b>Remaining</b></td></tr>
+        #{("<tr><td>#{school}</td></tr>" for school in @schools.left).join('')}
+      </table>
 
-        <table class='class_table school-list start-hidden'>
-          <tr><td><b>Done</b></td></tr>
-          #{("<tr><td>#{school}</td></tr>" for school in @schools.done).join('')}
-        </table>
-      </section>
+      <table class='class_table school-list start-hidden'>
+        <tr><td><b>Done</b></td></tr>
+        #{("<tr><td>#{school}</td></tr>" for school in @schools.done).join('')}
+      </table>
+      
     "
 

--- a/app/_attachments/js/modules/workflow/ValidObservationView.coffee
+++ b/app/_attachments/js/modules/workflow/ValidObservationView.coffee
@@ -142,12 +142,11 @@ class ValidObservationView extends Backbone.View
       previousMonth = 0
 
     @$el.html "
-      <section>
-        <h2>Valid Observations</h2>
-        <table class='class_table'><tr><th></th><th>Observations</th><th>Reimbursement</th></tr>
-          <tr><th>This month</th><td>#{@validCount.thisMonth} </td><td>#{thisMonth} KES</td></tr>
-          <tr><th>Previous month</th><td>#{@validCount.lastMonth} </td><td>#{previousMonth} KES</td></tr>
-        </table>
-      </section>
+      <h2>Valid Observations</h2>
+      <table class='class_table'><tr><th></th><th>Observations</th><th>Reimbursement</th></tr>
+        <tr><th>This month</th><td>#{@validCount.thisMonth} </td><td>#{thisMonth} KES</td></tr>
+        <tr><th>Previous month</th><td>#{@validCount.lastMonth} </td><td>#{previousMonth} KES</td></tr>
+      </table>
+      
     "
 

--- a/app/_attachments/js/modules/workflow/WorkflowMenuView.coffee
+++ b/app/_attachments/js/modules/workflow/WorkflowMenuView.coffee
@@ -83,39 +83,10 @@ class WorkflowMenuView extends Backbone.View
   renderMobile: =>
 
     @$el.html "
-      <h1>Tutor menu</h1>
       <ul class='workflow-menu'></ul>
-      <div id='sync-manager' class='SyncManagerView'></div>
-      <div id='school-list' class='SchoolListView'>pre</div>
-      <div id='valid-observations' class='ValidObservationView'>pre</div>
-      <div id='bandwidth-test'></div>
     "
 
     @updateWorkflows()
-
-    unless @schoolListView?
-      @schoolListView = new SchoolListView
-      @schoolListView.setElement(@$el.find("#school-list"))
-      @schoolListView.render("loading")
-
-    unless @validObservationView?
-      @validObservationView = new ValidObservationView
-      @validObservationView.setElement(@$el.find("#valid-observations"))
-      @validObservationView.render("loading")
-
-    unless @syncManagerView?
-      @syncManagerView = new SyncManagerView
-      @syncManagerView.setElement(@$el.find("#sync-manager"))
-      @listenTo @syncManagerView, "complete-sync", =>
-        @workflows.fetch
-          success: =>
-            @updateWorkflows()
-      @syncManagerView.render()
-
-    unless @bandwidthCheckView?
-      @bandwidthCheckView = new BandwidthCheckView
-      @bandwidthCheckView.setElement(@$el.find("#bandwidth-test"))
-      @bandwidthCheckView.render()
     
     @trigger "rendered"
 
@@ -136,12 +107,10 @@ class WorkflowMenuView extends Backbone.View
         feedbackHtml = ""
 
       htmlWorkflows += "
-        <li id='#{workflow.id}' style='margin-bottom:25px;'>
-          <section>
+        <li id='#{workflow.id}' style='margin-bottom:12px; padding-bottom: 12px; border-bottom: 1px solid #eee;'>
             <a href='#workflow/run/#{workflow.id}' class='workflow-button-link'>#{workflow.get('name')}</a>
             #{feedbackHtml}
             <div id='resume-workflow-#{workflow.id}'></div>
-          </section>
         </li>
         "
     @$el.find(".workflow-menu").html htmlWorkflows

--- a/app/_attachments/js/router.coffee
+++ b/app/_attachments/js/router.coffee
@@ -27,6 +27,9 @@ class Router extends Backbone.Router
 
     'tutor-account' : 'tutorAccount'
 
+    'tutor-menu'      : 'tutorMenu'
+    'tutor-menu/:tab' : 'tutorMenu'
+
     # Class
     'class'          : 'klass'
     'class/edit/:id' : 'klassEdit'
@@ -94,6 +97,11 @@ class Router extends Backbone.Router
     Tangerine.user.verify
       isAuthenticated: ->
         vm.show new TutorAccountView
+
+  tutorMenu: ( tab = 'workflows' ) ->
+    Tangerine.user.verify
+      isAuthenticated: ->
+        vm.show((new TutorMenuView selectedTab : tab) , true)
 
   email: ->
     Tangerine.user.verify
@@ -317,7 +325,7 @@ class Router extends Backbone.Router
       satellite: ->
         Tangerine.router.navigate "assessments", callFunction
       mobile: ->
-        Tangerine.router.navigate "assessments", callFunction
+        Tangerine.router.navigate "tutor-menu", callFunction
       klass: ->
         Tangerine.router.navigate "class", callFunction
 

--- a/app/_attachments/js/uglify.rb
+++ b/app/_attachments/js/uglify.rb
@@ -156,6 +156,7 @@ jsFiles = [
   'modules/user/UsersMenuView.js',
   'modules/user/UserEditView.js',
   'modules/user/TutorAccountView.js',
+  'modules/user/TutorMenuView.js',
 
   'modules/workflow/WorkflowStep.js',
   'modules/workflow/WorkflowSteps.js',

--- a/app/_attachments/locales/en/translation.coffee
+++ b/app/_attachments/locales/en/translation.coffee
@@ -43,7 +43,12 @@
       "gender"     : "Gender"
       "phone"      : "Phone"
       "email"      : "Email"
-
+  "TutorMenuView" :
+    "title" : "Tutor Menu"
+    "tabs" : 
+      "workflows" : "Workflows"
+      "sync" : "Sync"
+      "schools" : "Schools"
 
   "QuestionsEditListElementView" :
     "help" :

--- a/app/_attachments/locales/en/translation.json
+++ b/app/_attachments/locales/en/translation.json
@@ -50,6 +50,14 @@
       "email": "Email"
     }
   },
+  "TutorMenuView": {
+    "title": "Tutor Menu",
+    "tabs": {
+      "workflows": "Workflows",
+      "sync": "Sync",
+      "schools": "Schools"
+    }
+  },
   "QuestionsEditListElementView": {
     "help": {
       "copy_to": "Copy to",
@@ -87,6 +95,18 @@
       "attempt": "Attempt #__count__",
       "retrying": "Retrying...",
       "searching": "Searching..."
+    }
+  },
+  "CameraRunView": {
+    "title": "Capture Photo",
+    "button": {
+      "capture": "Capture Photo",
+      "browse": "Browse Photos"
+    },
+    "error": {
+      "capture": "An error occurred while importing the photo. Please try again.",
+      "noCamera": "System Error: No Camera Available to Capture Photo.",
+      "invalid": "You must capture a photograph before you can continue."
     }
   },
   "abort all observations": "Abort ALL observations",


### PR DESCRIPTION
The landing page has been split up, and slightly dressed up, into a 3-tab interface. During inital testing, things are looking good. I still need to complete the testing on the device against a "real" group to verify that the sync and upload functionality is still functional.

*\* Please don't merge until I have the testing complete. I just wanted to get the discussion rolling with the Pull Request.
